### PR TITLE
Fixed CMD Parameters

### DIFF
--- a/Fibaro UBS.groovy
+++ b/Fibaro UBS.groovy
@@ -430,12 +430,12 @@ if (logEnable) log.debug "BasicSet V1 ${cmd.inspect()}"
  	if (cmd.commandClass == 32) {
        if (state.ContactUsed) def currentstate
        if (state.MotionUsed) def motionstate
- 		if (cmd.parameter == [0]) {
+ 		if (cmd.parameter[0] == 0) {
  		if (state.ContactUsed) currentstate = "closed"
         if (state.MotionUsed) motionstate = "active"
 
 		}
- 		if (cmd.parameter == [255]) {
+ 		if (cmd.parameter[0] == 255) {
  		if (state.ContactUsed) currentstate = "open"
         if (state.MotionUsed) motionstate = "inactive"
 


### PR DESCRIPTION
The Zwave command parameters weren't being parsed correctly, and my contact states were always shown as "null." After applying this fix, the correct states are now being logged.